### PR TITLE
Adding --mirror to git clone for full repo

### DIFF
--- a/backup_codecommit.sh
+++ b/backup_codecommit.sh
@@ -26,7 +26,7 @@ declare -a repos=(`aws codecommit list-repositories | jq -r '.repositories[].rep
 for codecommitrepo in "${repos[@]}"
 do  
     echo "[===== Cloning repository: ${codecommitrepo} =====]"
-    git clone "https://git-codecommit.${AWS_DEFAULT_REGION}.amazonaws.com/v1/repos/${codecommitrepo}"
+    git clone --mirror "https://git-codecommit.${AWS_DEFAULT_REGION}.amazonaws.com/v1/repos/${codecommitrepo}"
 
     dt=$(date -u '+%Y_%m_%d_%H_%M')
     zipfile="${codecommitrepo}_backup_${dt}_UTC.tar.gz"


### PR DESCRIPTION
Just doing a `git clone` doesn't backup the full repo. Adding `--mirror` will include all metadata.