### PR TITLE
Parallelize with GNU Parallel

### DIFF
--- a/backup_codecommit.sh
+++ b/backup_codecommit.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# 
+#
 # Licensed under the Amazon Software License (the "License").
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
-# 
+#
 # http://aws.amazon.com/asl/
-# 
+#
 # or in the "license" file accompanying this file. This file is distributed
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
@@ -23,18 +23,14 @@ git config --global credential.UseHttpPath true
 
 declare -a repos=(`aws codecommit list-repositories | jq -r '.repositories[].repositoryName'`)
 
-for codecommitrepo in "${repos[@]}"
-do  
-    echo "[===== Cloning repository: ${codecommitrepo} =====]"
-    git clone "https://git-codecommit.${AWS_DEFAULT_REGION}.amazonaws.com/v1/repos/${codecommitrepo}"
+if ! parallel --joblog /tmp/log --jobs 400% --max-args=1 \
+  ./backup_repo.sh "${backup_s3_bucket}" {} ::: "${repos[@]}"
+then
+  for i in {1..3}
+  do
+    sleep $(( i * 5 ))
+    parallel --resume-failed --joblog /tmp/log --jobs 400% --max-args=1 \
+      ./backup_repo.sh "${backup_s3_bucket}" {} ::: "${repos[@]}" && break
+  done
+fi
 
-    dt=$(date -u '+%Y_%m_%d_%H_%M')
-    zipfile="${codecommitrepo}_backup_${dt}_UTC.tar.gz"
-    echo "Compressing repository: ${codecommitrepo} into file: ${zipfile} and uploading to S3 bucket: ${backup_s3_bucket}/${codecommitrepo}"
-
-    tar -zcvf "${zipfile}" "${codecommitrepo}/"
-    aws s3 cp "${zipfile}" "s3://${backup_s3_bucket}/${codecommitrepo}/${zipfile}" --region $AWS_DEFAULT_REGION
-
-    rm $zipfile
-    rm -rf "$codecommitrepo"
-done

--- a/backup_repo.sh
+++ b/backup_repo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Amazon Software License (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -ex
+
+backup_s3_bucket="${1}"
+codecommitrepo="${2}"
+
+trap 'rm -rf "${codecommitrepo}"; [[ -n "${zipfile:-}" ]] && rm -f "${zipfile}"' EXIT
+
+echo "[===== Cloning repository: ${codecommitrepo} =====]"
+git clone "https://git-codecommit.${AWS_DEFAULT_REGION}.amazonaws.com/v1/repos/${codecommitrepo}"
+
+dt=$(date -u "+%Y_%m_%d_%H_%M")
+zipfile="${codecommitrepo}_backup_${dt}_UTC.tar.gz"
+echo "Compressing repository: ${codecommitrepo} into file: ${zipfile} and uploading to S3 bucket: ${backup_s3_bucket}/${codecommitrepo}"
+
+tar -zcvf "${zipfile}" "${codecommitrepo}/"
+aws s3 cp "${zipfile}" "s3://${backup_s3_bucket}/${codecommitrepo}/${zipfile}" --region $AWS_DEFAULT_REGION
+

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,7 @@ phases:
   install:
     commands:
       - apt-get update -y
-      - apt-get install -y jq
+      - apt-get install -y jq parallel
 
   build:
     commands:


### PR DESCRIPTION
*Description of changes:*

This reduces run-time and cost by using all cores on the CodeBuild instance while performing the backup.  I observe a ~67% reduction in my case.

A retry loop handles rate throttling from CodeCommit. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
