### PR TITLE
Update IAM permissions for backup lamba

### DIFF
--- a/codecommit_backup_cfn_template.yaml
+++ b/codecommit_backup_cfn_template.yaml
@@ -44,12 +44,6 @@ Resources:
                 Action: 
                   - "logs:*"
                 Resource: "arn:aws:logs:*:*:*"
-              - 
-                Effect: "Allow"
-                Action: 
-                  - "s3:GetObject"
-                  - "s3:GPutbject"
-                Resource: "arn:aws:s3:::*"
         - 
           PolicyName: "codebuild"
           PolicyDocument: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed IAM permissions. Backup Lambda does not interact with S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
