### PR TITLE
Modernize build image and Python runtime

### DIFF
--- a/backup_repo.sh
+++ b/backup_repo.sh
@@ -28,5 +28,5 @@ zipfile="${codecommitrepo}_backup_${dt}_UTC.tar.gz"
 echo "Compressing repository: ${codecommitrepo} into file: ${zipfile} and uploading to S3 bucket: ${backup_s3_bucket}/${codecommitrepo}"
 
 tar -zcvf "${zipfile}" "${codecommitrepo}/"
-aws s3 cp "${zipfile}" "s3://${backup_s3_bucket}/${codecommitrepo}/${zipfile}" --region $AWS_DEFAULT_REGION
+aws s3 cp "${zipfile}" "s3://${backup_s3_bucket}/${codecommitrepo}/${zipfile}" --region "$AWS_DEFAULT_REGION"
 

--- a/codecommit_backup_cfn_template.yaml
+++ b/codecommit_backup_cfn_template.yaml
@@ -59,7 +59,7 @@ Resources:
     Properties:
       FunctionName: CodeCommitBackupLambda
       Handler: codecommit_backup_trigger_lambda.handler
-      Runtime: python3.6
+      Runtime: python3.9
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt CodeCommitBackupLambdaRole.Arn
@@ -160,7 +160,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Image: aws/codebuild/python:3.5.2
+        Image: aws/codebuild/standard:6.0-23.02.16
         EnvironmentVariables: 
           - 
             Name: CodeCommitBackupsS3Bucket

--- a/codecommit_backup_trigger_lambda.py
+++ b/codecommit_backup_trigger_lambda.py
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: MIT-0
 
 import boto3
-client = boto3.client('codebuild')
-def handler(event, context): 
-    response = client.start_build(projectName='CodeCommitBackup')
-    output = "Triggered CodeBuild project: 'CodeCommitBackup' to back all CodeCommit repos in this account/region. Status={}".format(response["build"]["buildStatus"])
+
+client = boto3.client("codebuild")
+
+
+def handler(event, context):
+    response = client.start_build(projectName="CodeCommitBackup")
+    output = (
+        "Triggered CodeBuild project: 'CodeCommitBackup' to back"
+        " all CodeCommit repos in this account/region. Status={}"
+    ).format(response["build"]["buildStatus"])
     print(output)
     return output

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,6 @@ stack_name="codecommit-backups"
 
 # You can also change these parameters but it's not required
 cfn_template="codecommit_backup_cfn_template.yaml"
-cfn_parameters="codecommit_backup_cfn_parameters.json"
 zipfile="codecommit_backup_scripts.zip"
 cfn_gen_template="/tmp/gen_codecommit_backup_cfn_template.yaml"
 


### PR DESCRIPTION
The build image and Python runtime seem to be somewhat out of date.  It would be great to see the upstream source incorporate these changes so deployers don't have to worry about out of date Lambda runtimes or EOL build images.

My linter also pointed out a few shell issues with quoting, long lines, and dead code.  I made those changes as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
